### PR TITLE
subdomain proof of concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,14 @@ You can add rules via Config API:
 
 ```yml
 TranslatableTLDs:
+  part: 'tld'
   rules:
     'com': 'en_US'
     'de': 'de_DE'
     'net': 'de_AT'
 ```
+
+If part is set to 'subdomain', then the module will switch to subdomain matching.
 
 ## Maintainers
 - Julian Scheuchenzuber <js@lvl51.de>

--- a/_config/translatabletlds.yml
+++ b/_config/translatabletlds.yml
@@ -6,6 +6,7 @@ After:
 Translatable:
   enforce_global_unique_urls: false
 TranslatableTLDs:
+  part: tld # valid values are tld and subdomain
   rules:
     'com': 'en_US'
     'de': 'de_DE'

--- a/code/TranslatableTLDs.php
+++ b/code/TranslatableTLDs.php
@@ -10,8 +10,9 @@ class TranslatableTLDs {
      *
      * @return string
      */
-    public static function get_tld() {
-        return pathinfo($_SERVER['SERVER_NAME'], PATHINFO_EXTENSION);
+    public static function get_tld($part == 'tld') {
+        
+        return ($part == 'tld')?(pathinfo($_SERVER['SERVER_NAME'], PATHINFO_EXTENSION)):array_shift((explode(".",$_SERVER['HTTP_HOST'])));
     }
 
     /**
@@ -21,7 +22,8 @@ class TranslatableTLDs {
      */
     public static function lookup_tld_rule() {
         $rules = Config::inst()->get(self::class, 'rules');
+        $part = Config::inst()->get(self::class, 'part');
 
-        return isset($rules[self::get_tld()]) ? $rules[self::get_tld()] : null;
+        return isset($rules[self::get_tld()]) ? $rules[self::get_tld($part)] : null;
     }
 }


### PR DESCRIPTION
Did not test this code, just edited the fork in GitHub as a proof of concept.

Please check it out and develop it more, it enables with a flag in config yaml file to match also for subdomains, for example

mydomain.com -> en
de.mydomain.com -> de_DE
fr.mydomain.com -> fr_FR